### PR TITLE
Remove alertIfBelowBaseline from email and consumer shutdown logic to handle retries

### DIFF
--- a/src/services/alert/email.ts
+++ b/src/services/alert/email.ts
@@ -80,8 +80,7 @@ const generateHTMLReport = (
 export const sendAlertMail = async (
   alertConfig: Record<string, any> | undefined,
   result: Record<string, any>,
-  chosenStartegy: PSIStrategy = defaultStrategy,
-  onlyAlertIfBelowBaseline = false
+  chosenStartegy: PSIStrategy = defaultStrategy
 ) => {
   try {
     if (!alertConfig) {
@@ -96,36 +95,12 @@ export const sendAlertMail = async (
     if (!email.id) {
       throw new Error('Email id not found in alertConfig, add one by /PATCH to /alert');
     }
-    let alertResults: Record<string, any> | null = null;
-    if (onlyAlertIfBelowBaseline) {
-      for (const url in result) {
-        if (result[url].failed) {
-          continue;
-        }
-        for (const category in result[url]) {
-          if (result[url][category].failed) {
-            continue;
-          }
-          if (result[url][category].alertRequired) {
-            if (!alertResults) {
-              alertResults = {};
-            }
-            alertResults[url] = {
-              ...alertResults[url],
-              [category]: result[url][category],
-            };
-          }
-        }
-      }
-    } else {
-      alertResults = result;
-    }
-    if (!alertResults) {
+    if (!result) {
       return {
         message: `No alert required for this report`,
       };
     }
-    const html = generateHTMLReport(alertResults, chosenStartegy);
+    const html = generateHTMLReport(result, chosenStartegy);
     const mailOptions = {
       to: email.id,
       html,

--- a/src/services/message/alert.ts
+++ b/src/services/message/alert.ts
@@ -32,8 +32,7 @@ export const alertMessageHandler = async (message: Message, cb: (err?: Error) =>
     const emailAlertStatus = await sendAlertMail(
       alertConfig as Record<string, unknown>,
       result as Record<string, unknown>,
-      chosenStartegy as PSIStrategy,
-      onlyAlertIfBelowBaseline
+      chosenStartegy as PSIStrategy
     );
     const slackAlertStatus = await sendAlertToSlackChannel(
       alertConfig as Record<string, unknown>,

--- a/src/services/message/alert.ts
+++ b/src/services/message/alert.ts
@@ -63,7 +63,7 @@ export const alertMessageHandler = async (message: Message, cb: (err?: Error) =>
       }
     } else console.log('socket connection not found, unable to notify client');
     cb();
-  } catch (e: any) {
+  } catch (e: unknown) {
     console.log('Error occured in alertMessageHandler', e);
     messageStatus = setMessageStatus(
       msgId,
@@ -75,6 +75,6 @@ export const alertMessageHandler = async (message: Message, cb: (err?: Error) =>
       clientId
     );
     if (socketId) io.to(socketId).emit('status', messageStatus);
-    cb(e);
+    cb(e as Error);
   }
 };

--- a/src/services/message/compare.ts
+++ b/src/services/message/compare.ts
@@ -64,7 +64,7 @@ export const compareMessageHandler = async (message: Message, cb: (err?: Error) 
     if (socketId) io.to(socketId).emit('status', messageStatus);
     else console.log('socket connection not found, unable to notify client');
     cb();
-  } catch (e: any) {
+  } catch (e: unknown) {
     console.log('Error occured in compareMessageHandler', e);
     messageStatus = setMessageStatus(
       msgId,
@@ -76,6 +76,6 @@ export const compareMessageHandler = async (message: Message, cb: (err?: Error) 
       clientId
     );
     if (socketId) io.to(socketId).emit('status', messageStatus);
-    cb(e);
+    cb(e as Error);
   }
 };

--- a/src/services/message/compare.ts
+++ b/src/services/message/compare.ts
@@ -53,7 +53,6 @@ export const compareMessageHandler = async (message: Message, cb: (err?: Error) 
       clientId
     );
 
-    //TODO: push the data to alert queue
     await createQueue(ALERT_QUEUE_NAME);
     const cmessage = createMessage(
       { result, alertConfig, chosenStartegy, clientId },

--- a/src/services/message/trigger.ts
+++ b/src/services/message/trigger.ts
@@ -80,7 +80,7 @@ export const triggerMessageHandler = async (message: Message, cb: (err?: Error) 
     if (socketId) io.to(socketId).emit('status', messageStatus);
     else console.log('socket connection not found, unable to notify client');
     cb();
-  } catch (e: any) {
+  } catch (e: unknown) {
     console.error('Error occured in triggerMessageHandler', e);
     messageStatus = setMessageStatus(
       msgId,
@@ -93,6 +93,6 @@ export const triggerMessageHandler = async (message: Message, cb: (err?: Error) 
     );
 
     if (socketId) io.to(socketId).emit('status', messageStatus);
-    cb(e);
+    cb(e as Error);
   }
 };

--- a/src/services/redis_smq.ts
+++ b/src/services/redis_smq.ts
@@ -71,19 +71,13 @@ export const createMessage = (body: unknown, queueName: string) => {
 
 export const runConsumer = (consumer: Consumer) => {
   return new Promise((resolve, reject) => {
-    console.log('Running consumer');
-    consumer.run((err, status) => {
+    consumer.run((err, reply) => {
       if (err) reject(err);
-      if (status) {
-        consumer.shutdown((err, reply) => {
-          if (err) reject(err);
-          console.log('Consumer shutdown');
-          resolve(reply);
-        });
-      }
+      resolve(reply);
     });
   });
 };
+
 export const setupConsumers = async (
   queueName: string,
   messageHandler: (message: Message, cb: (err?: Error) => void) => Promise<void>,


### PR DESCRIPTION
closes #20 
- removed alertIfBelowBaseline from email logic, as table gets messed up
- removed consumer shutdown logic as it leads to unacknowledged messages not being handled.